### PR TITLE
Fix install rule.

### DIFF
--- a/nao_dcm_driver/CMakeLists.txt
+++ b/nao_dcm_driver/CMakeLists.txt
@@ -52,10 +52,6 @@ else()
 endif()
 
 
-install(TARGETS nao_dcm_driver
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
 # install(DIRECTORY launch 
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 


### PR DESCRIPTION
It made catkin_make fail on a system without NAOqi C++ sdk. The error was:

-- Cannot find NAOqi C++ sdk; C++ nodes will NOT be built
CMake Error at nao_dcm_robot/nao_dcm_driver/CMakeLists.txt:55 (install):
  install TARGETS given target nao_dcm_driver which does not exist in this
  directory.