### PR TITLE
Do not search naoqi libraries in ROS paths, go directly in SDK path

### DIFF
--- a/nao_dcm_driver/cmake/FindNAOqi.cmake
+++ b/nao_dcm_driver/cmake/FindNAOqi.cmake
@@ -113,7 +113,7 @@ set(NAOqi_FOUND_COMPONENTS TRUE)
 if( ${NAOqi_NUMBER_OF_COMPONENTS}  )
     foreach(comp ${NAOqi_FILTERED_COMPONENTS})
         #Look for the actual library here
-        find_library(${comp}_LIBRARY NAMES ${comp} HINTS ${NAOqi_LIBRARY_HINTS})
+        find_library(${comp}_LIBRARY NAMES ${comp} HINTS ${NAOqi_LIBRARY_HINTS} NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH)
         if ( ${${comp}_LIBRARY} STREQUAL ${comp}_LIBRARY-NOTFOUND)
             message(STATUS "Could not find NAOqi's ${comp}")
             set(NAOqi_FOUND_COMPONENTS FALSE)


### PR DESCRIPTION
If libqi was installed via ROS (ros-indigo-naoqi-libqi for instance) cmake will automatically link towards that one. But when using NAOqi SDK, we want to use libqi.so in the SDK, not the one from the system. Doing otherwise might lead to several "undefined reference" errors at build time. 